### PR TITLE
Set `pass_filenames: true` 

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,6 @@
   name: Check Ruby files with StandardRB
   description: Standard - Ruby style guide, linter, and formatter
   entry: standardrb
-  pass_filenames: false
+  pass_filenames: true
   language: ruby
   types: ["ruby"]


### PR DESCRIPTION
This reverts fa8b50586d2bafe59dd3e48ceac14f6f8f7b1b8b and sets `pass_filenames: true`. This allows `standardrb` to only run on the files modified in the commit instead of every file in the repo every single time.

Documentation:
https://pre-commit.com/#hooks-pass_filenames