### PR TITLE
Upgrade to StandardRB v1.22.1

### DIFF
--- a/pre_commit_fake_gem.gemspec
+++ b/pre_commit_fake_gem.gemspec
@@ -4,6 +4,6 @@ Gem::Specification.new do |s|
   s.authors = ["Jamie Alessio"]
   s.summary = "A fake gem for pre-commit-standardrb"
   s.description = "A fake gem for pre-commit-standardrb"
-  s.add_dependency "standard", "1.4.0"
+  s.add_dependency "standard", "1.22.1"
   s.required_ruby_version = ">= 2.5"
 end


### PR DESCRIPTION
Upgrade [StandardRB v1.22.1](https://github.com/testdouble/standard/releases/tag/v1.21.0) to take advantage of features outlined in https://blog.testdouble.com/posts/2023-01-19-super-standard-adding-gem-extensions-and-custom-rules/
