### PR TITLE
Upgrade to StandardRB v1.26.0

### DIFF
--- a/pre_commit_fake_gem.gemspec
+++ b/pre_commit_fake_gem.gemspec
@@ -4,6 +4,6 @@ Gem::Specification.new do |s|
   s.authors = ["Jamie Alessio"]
   s.summary = "A fake gem for pre-commit-standardrb"
   s.description = "A fake gem for pre-commit-standardrb"
-  s.add_dependency "standard", "1.22.1"
+  s.add_dependency "standard", "1.26.0"
   s.required_ruby_version = ">= 2.5"
 end


### PR DESCRIPTION
Upgrades to https://github.com/testdouble/standard/releases/tag/v1.26.0